### PR TITLE
fix: correct base test case

### DIFF
--- a/__tests__/fixtures/TestCase.php
+++ b/__tests__/fixtures/TestCase.php
@@ -10,7 +10,7 @@ use Illuminate\Foundation\Application;
  *
  * @see https://github.com/orchestral/testbench#usage
  */
-class TestCase extends OrchestraTestCase
+abstract class TestCase extends OrchestraTestCase
 {
     /**
      * Include the package's service provider(s)

--- a/generators/app/templates/tests/_TestCase.php
+++ b/generators/app/templates/tests/_TestCase.php
@@ -10,7 +10,7 @@ use Illuminate\Foundation\Application;
  *
  * @see https://github.com/orchestral/testbench#usage
  */
-class TestCase extends OrchestraTestCase
+abstract class TestCase extends OrchestraTestCase
 {
     /**
      * Include the package's service provider(s)


### PR DESCRIPTION
Currently, the base test case is not declared abstract. This produces warnings from PHPunit when running all the tests on 9.0. Fixed by making it abstract :)