### PR TITLE
fix: gitignore composer lock

### DIFF
--- a/generators/app/templates/_.gitignore.main
+++ b/generators/app/templates/_.gitignore.main
@@ -1,1 +1,2 @@
 /vendor
+composer.lock


### PR DESCRIPTION
It's generally accepted that this shouldn't be committed in libraries. It has no effect on downstream installs, only for other people working on the package (and will cause issues if they have different php versions/extensions/etc).